### PR TITLE
Allowing castling notation for O and 0

### DIFF
--- a/js/jquery.chess-replayer.js
+++ b/js/jquery.chess-replayer.js
@@ -288,8 +288,8 @@ var DEBUG = true;
             commentLeftParen: /\{([^}]*?)(\()(.*?)\}/g,
             commentRightParen: /\{([^}]*?)(\))(.*?)\}/g,
 
-            castleKingside: /^O-O/,
-            castleQueenside: /^O-O-O/,
+            castleKingside: /^O-O|0-0/,
+            castleQueenside: /^O-O-O|0-0-0/,
 
             pieceMove: /^([KQBNR])/,
             pieceDest: /(.*)([a-h])([1-8])/,


### PR DESCRIPTION
Changed the regex's for detecting castling moves to allow both O-O-O and 0-0-0 for long castle, as well as O-O and 0-0 for short castle.

This follows up from the [Chess SE meta request](https://chess.meta.stackexchange.com/questions/542/castling-notation-in-replayer) to be able to use both zeros and upper case o's notations.